### PR TITLE
apply sort for childhood, adult and traits lists in filters

### DIFF
--- a/Source/PrepareModerately/PrepareModerately/Filter/Part/Types/HasAdulthood.cs
+++ b/Source/PrepareModerately/PrepareModerately/Filter/Part/Types/HasAdulthood.cs
@@ -39,7 +39,9 @@ namespace Lakuna.PrepareModerately.Filter.Part.Types {
 			}
 #else
 			if (Widgets.ButtonText(rect, this.backstory.title.CapitalizeFirst())) {
-				FloatMenuUtility.MakeMenu(DefDatabase<BackstoryDef>.AllDefsListForReading.Where((BackstoryDef def) => def.slot == BackstorySlot.Adulthood),
+				var sortedDefs = DefDatabase<BackstoryDef>.AllDefsListForReading.OrderBy(def => def.title);
+				
+				FloatMenuUtility.MakeMenu(sortedDefs.Where((BackstoryDef def) => def.slot == BackstorySlot.Adulthood),
 					(BackstoryDef def) => def.title.CapitalizeFirst(),
 					(BackstoryDef def) => () => this.backstory = def);
 			}

--- a/Source/PrepareModerately/PrepareModerately/Filter/Part/Types/HasChildhood.cs
+++ b/Source/PrepareModerately/PrepareModerately/Filter/Part/Types/HasChildhood.cs
@@ -39,7 +39,10 @@ namespace Lakuna.PrepareModerately.Filter.Part.Types {
 			}
 #else
 			if (Widgets.ButtonText(rect, this.backstory.title.CapitalizeFirst())) {
-				FloatMenuUtility.MakeMenu(DefDatabase<BackstoryDef>.AllDefsListForReading.Where((BackstoryDef def) => def.slot == BackstorySlot.Childhood),
+
+				var sortedDefs = DefDatabase<BackstoryDef>.AllDefsListForReading.OrderBy(def => def.title);
+				
+				FloatMenuUtility.MakeMenu(sortedDefs.Where((BackstoryDef def) => def.slot == BackstorySlot.Childhood),
 					(BackstoryDef def) => def.title.CapitalizeFirst(),
 					(BackstoryDef def) => () => this.backstory = def);
 			}

--- a/Source/PrepareModerately/PrepareModerately/Filter/Part/Types/HasTrait.cs
+++ b/Source/PrepareModerately/PrepareModerately/Filter/Part/Types/HasTrait.cs
@@ -49,8 +49,10 @@ namespace Lakuna.PrepareModerately.Filter.Part.Types {
 			if (Widgets.ButtonText(rect, this.traitDegreePair.TraitDegreeData.label.CapitalizeFirst())) {
 #else
 			if (Widgets.ButtonText(rect, this.traitDegreePair.TraitDegreeData.LabelCap)) {
+
+				var sortedPairs = TraitDegreePair.TraitDegreePairs.OrderBy(pair => pair.TraitDegreeData.LabelCap);
 #endif
-				FloatMenuUtility.MakeMenu(TraitDegreePair.TraitDegreePairs,
+				FloatMenuUtility.MakeMenu(sortedPairs,
 #if V1_0
 					(TraitDegreePair traitDegreePair) => traitDegreePair.TraitDegreeData.label.CapitalizeFirst(),
 #else


### PR DESCRIPTION
Hello, I like this mod but picking process for traits or childhood/adulthood origins in character filter is a bit painful.
I propose a little change for large lists that also used in RandomPlus mod.
I sorted by alphabetical order defs data by title in adulthood/childhood/traits list to achieve better readability while setting up a filter.

I hope you'll find it useful.